### PR TITLE
Mixin improvements

### DIFF
--- a/src/main/java/com/teamabode/guarding/core/mixin/NetheriteShieldMixin.java
+++ b/src/main/java/com/teamabode/guarding/core/mixin/NetheriteShieldMixin.java
@@ -1,17 +1,11 @@
 package com.teamabode.guarding.core.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.teamabode.guarding.core.registry.GuardingItems;
-import com.teamabode.guarding.core.registry.GuardingSounds;
-import net.minecraft.stats.Stat;
-import net.minecraft.stats.Stats;
-import net.minecraft.util.Mth;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemCooldowns;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -28,25 +22,9 @@ public abstract class NetheriteShieldMixin extends LivingEntity {
         super(entityType, level);
     }
 
-    @Shadow public abstract void awardStat(Stat<?> stat);
-
-    @Inject(method = "hurtCurrentlyUsedShield", at = @At("HEAD"), cancellable = true)
-    private void guarding$hurtCurrentlyUsedShield(float damageAmount, CallbackInfo ci) {
-        if (useItem.is(GuardingItems.NETHERITE_SHIELD)) {
-            if (!level().isClientSide) this.awardStat(Stats.ITEM_USED.get(useItem.getItem()));
-            if (damageAmount >= 3.0f) {
-                int damage = 1 + Mth.floor(damageAmount);
-                InteractionHand hand = this.getUsedItemHand();
-
-                useItem.hurtAndBreak(damage, this, getSlotForHand(hand));
-                if (useItem.isEmpty()) {
-                    this.setItemSlot(hand == InteractionHand.MAIN_HAND ? EquipmentSlot.MAINHAND : EquipmentSlot.OFFHAND, ItemStack.EMPTY);
-                    this.useItem = ItemStack.EMPTY;
-                    this.playSound(GuardingSounds.ITEM_NETHERITE_SHIELD_BREAK, 0.8f, 0.8f + this.level().random.nextFloat() * 0.4f);
-                }
-            }
-            ci.cancel();
-        }
+    @ModifyExpressionValue(method = "hurtCurrentlyUsedShield", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/world/item/Item;)Z"))
+    private boolean guarding$hurtCurrentlyUsedShield(boolean original) {
+        return original || useItem.is(GuardingItems.NETHERITE_SHIELD);
     }
 
     @Inject(method = "disableShield", at = @At("HEAD"))

--- a/src/main/java/com/teamabode/guarding/core/mixin/NetheriteShieldSoundMixin.java
+++ b/src/main/java/com/teamabode/guarding/core/mixin/NetheriteShieldSoundMixin.java
@@ -17,12 +17,11 @@ public abstract class NetheriteShieldSoundMixin {
 
     @Shadow public abstract ItemStack getUseItem();
 
-    @Inject(method = "hurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;broadcastEntityEvent(Lnet/minecraft/world/entity/Entity;B)V", shift = At.Shift.BEFORE), cancellable = true)
+    @Inject(method = "hurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;broadcastEntityEvent(Lnet/minecraft/world/entity/Entity;B)V"))
     private void guarding$hurt(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
         if (this.getUseItem().is(GuardingItems.NETHERITE_SHIELD)) {
             LivingEntity livingEntity = LivingEntity.class.cast(this);
             livingEntity.level().playSound(null, livingEntity.blockPosition(), GuardingSounds.ITEM_NETHERITE_SHIELD_BLOCK, SoundSource.NEUTRAL, 1.0f, 1.0f);
-            cir.cancel();
         }
     }
 }


### PR DESCRIPTION
https://github.com/Team-Abode/guarding/blob/bd62ba845e76379699fa2f63d03b55099d3e3f70/src/main/java/com/teamabode/guarding/core/mixin/NetheriteShieldMixin.java#L33-L50

This is a copy-pasted method from vanilla code with just the initial check edited to check against the netherite shield, it is easily replacable with

```
@ModifyExpressionValue(method = "hurtCurrentlyUsedShield", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/world/item/Item;)Z"))
private boolean guarding$hurtCurrentlyUsedShield(boolean original) {
    return original || useItem.is(GuardingItems.NETHERITE_SHIELD);
}
```

This improves mod compatibility and removes unnecessary code by avoiding running the method for both shields twice, for example in my mod I am checking whether or not the shield was hurt to do custom behavior, and it does not work with the netherite shield because Guarding runs its own method. If I were to consider the netherite shield on my side, then the method would be run twice and the shield would take twice the damage. 

I've also removed the unnecessary method cancellation and bytecode shift here:

https://github.com/Team-Abode/guarding/blob/bd62ba845e76379699fa2f63d03b55099d3e3f70/src/main/java/com/teamabode/guarding/core/mixin/NetheriteShieldSoundMixin.java#L20-L27

since they don't seem to serve any purpose and the mod behaves the same with them removed.